### PR TITLE
Make idiomatic + minor bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 *.exe
 *.out
 *.app
+
+# Target executable
+main

--- a/Images.cpp
+++ b/Images.cpp
@@ -2,22 +2,61 @@
 // Created by mereckaj on 11/11/15.
 //
 
-#include <opencv2/core/mat.hpp>
-#include <opencv2/imgcodecs.hpp>
+#include <cstdlib>
+#include <algorithm>              // min
+#include <string>
+#include <vector>
 #include <iostream>
+
+#include <opencv2/core.hpp>
+#include <opencv2/imgcodecs.hpp>  // imread
+
 #include "Images.h"
 
+const std::string IMAGE_LOCATION{"Images/"};
 
-cv::Mat* LoadImages(char* imageLocation,char*imageNames[],int imageCount){
-    cv::Mat *images = new cv::Mat[imageCount];
-    for (int i = 0; i < imageCount; i++) {
-        std::string filename(IMAGE_LOCATION);
-        filename.append(imageNames[i]);
+const std::vector<std::string> VIEW_FILES{
+    "BookView01.JPG", "BookView02.JPG", "BookView03.JPG", "BookView04.JPG",
+    "BookView05.JPG", "BookView06.JPG", "BookView07.JPG", "BookView08.JPG",
+    "BookView09.JPG", "BookView10.JPG", "BookView11.JPG", "BookView12.JPG",
+    "BookView13.JPG", "BookView14.JPG", "BookView15.JPG", "BookView16.JPG",
+    "BookView17.JPG", "BookView18.JPG", "BookView19.JPG", "BookView20.JPG",
+    "BookView21.JPG", "BookView22.JPG", "BookView23.JPG", "BookView24.JPG",
+    "BookView25.JPG", "BookView26.JPG", "BookView27.JPG", "BookView28.JPG",
+    "BookView29.JPG", "BookView30.JPG", "BookView31.JPG", "BookView32.JPG",
+    "BookView33.JPG", "BookView34.JPG", "BookView35.JPG", "BookView36.JPG",
+    "BookView37.JPG", "BookView38.JPG", "BookView39.JPG", "BookView40.JPG",
+    "BookView41.JPG", "BookView42.JPG", "BookView43.JPG", "BookView44.JPG",
+    "BookView45.JPG", "BookView46.JPG", "BookView47.JPG", "BookView48.JPG",
+    "BookView49.JPG", "BookView50.JPG"
+};
+
+const std::vector<std::string> PAGE_FILES{
+    "Page01.jpg", "Page02.jpg", "Page03.jpg", "Page04.jpg", "Page05.jpg",
+    "Page06.jpg", "Page07.jpg", "Page08.jpg", "Page09.jpg", "Page10.jpg",
+    "Page11.jpg", "Page12.jpg", "Page13.jpg"
+};
+
+std::vector<cv::Mat> LoadImages(const std::string imageLocation,
+                                const std::vector<std::string> imageNames) {
+    return LoadImages(imageLocation, imageNames, imageNames.size());
+}
+
+std::vector<cv::Mat> LoadImages(const std::string imageLocation,
+                                const std::vector<std::string> imageNames,
+                                const size_t imageCount) {
+
+    const size_t nimages = std::min(imageCount, imageNames.size());
+    std::vector<cv::Mat> images(nimages);
+
+    for (size_t i = 0; i < nimages; i++) {
+        const std::string filename{IMAGE_LOCATION + imageNames[i]};
         images[i] = cv::imread(filename, cv::IMREAD_ANYCOLOR);
-        if (images[i].empty()) {
+        if (!images[i].data) {
             std::cerr << "Failed to load image: " << filename << std::endl;
-            exit(1);
+            exit(EXIT_FAILURE);
         }
-        return images;
     }
+
+    return images;
 }

--- a/Images.h
+++ b/Images.h
@@ -5,28 +5,18 @@
 #ifndef VISIONASSIGNMENT2_IMAGES_H
 #define VISIONASSIGNMENT2_IMAGES_H
 
-#define NUMBER_OF_PAGES 13
-#define NUMBER_OF_VIEWS 50
+#include <cstddef>
+#include <string>
+#include <vector>
 
-char * IMAGE_LOCATION = "/home/mereckaj/Dev/ClionProjects/VissionAssignment2/Images";
-char * viewFiles[] = {"BookView02.JPG","BookView03.JPG","BookView04.JPG","BookView05.JPG",
-                      "BookView06.JPG","BookView07.JPG","BookView08.JPG","BookView09.JPG",
-                      "BookView10.JPG","BookView11.JPG","BookView12.JPG","BookView13.JPG",
-                      "BookView14.JPG","BookView15.JPG","BookView16.JPG","BookView17.JPG",
-                      "BookView01.JPG","BookView18.JPG","BookView19.JPG","BookView20.JPG",
-                      "BookView21.JPG","BookView22.JPG","BookView23.JPG","BookView24.JPG",
-                      "BookView25.JPG","BookView26.JPG","BookView27.JPG","BookView28.JPG",
-                      "BookView29.JPG","BookView30.JPG","BookView31.JPG","BookView32.JPG",
-                      "BookView33.JPG","BookView34.JPG","BookView35.JPG","BookView36.JPG",
-                      "BookView37.JPG","BookView38.JPG","BookView39.JPG","BookView40.JPG",
-                      "BookView41.JPG","BookView42.JPG","BookView43.JPG","BookView44.JPG",
-                      "BookView45.JPG","BookView46.JPG","BookView47.JPG","BookView48.JPG",
-                      "BookView49.JPG","BookView50.JPG"};
-char * pageFiles[] = {"Page01.jpg","Page02.jpg","Page03.jpg","Page04.jpg",
-                      "Page05.jpg","Page06.jpg","Page07.jpg","Page08.jpg",
-                      "Page09.jpg","Page10.jpg","Page11.jpg","Page12.jpg",
-                      "Page13.jpg"};
+extern const std::string IMAGE_LOCATION;
+extern const std::vector<std::string> VIEW_FILES;
+extern const std::vector<std::string> PAGE_FILES;
 
+std::vector<cv::Mat> LoadImages(const std::string imageLocation,
+                                const std::vector<std::string> imageNames);
+std::vector<cv::Mat> LoadImages(const std::string imageLocation,
+                                const std::vector<std::string> imageNames,
+                                const size_t imageCount);
 
-cv::Mat* LoadImages(char* imageLocation,char*imageNames[],int imageCount);
 #endif //VISIONASSIGNMENT2_IMAGES_H

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,49 @@
+#!/usr/bin/env make
+
+#
+# Simple Makefile for OpenCV projects.
+#
+# Author: Basil L. Contovounesios <contovob@tcd.ie>
+#
+
+target := main
+source := $(target).cpp
+depens := $(filter-out $(source), $(wildcard *.cpp))
+
+# Emulates an if-else function for equating flags/text.
+# Usage: $(call ifflag, <flag>, <comparison>, <equal-value>, <unequal-value>)
+ifflag = $(strip $(if $(filter $(2), $(1)), $(3), $(4)))
+
+#
+# Make options controlling compilation flags and their defaults.
+#
+# For example, the following will disable optimisations and compiler warnings:
+#
+#   make glue OPT=false WARN=false
+#
+
+# Use the 2011 ISO C++ standard plus amendments
+override CXXFLAGS += $(call ifflag, $(GNU), true, -std=gnu++11, -std=c++11)
+# Optimise
+override CXXFLAGS += $(call ifflag, $(OPT), false, -O0, -O3)
+# Issue warnings
+override CXXFLAGS += $(call ifflag, $(WARN), false, -w, -pedantic -Wall)
+# Issue coloured text output
+override CXXFLAGS += $(call ifflag, $(COLOUR), false, , -fdiagnostics-color)
+
+# Change shared object directory to search according to installation
+override LDFLAGS  += -L/usr/local/lib
+
+# Remove if using OpenCV 2
+override LDLIBS   += -lopencv_imgcodecs
+# OpenCV libraries needed
+override LDLIBS   += -lopencv_core -lopencv_highgui
+
+.PHONY: clean
+
+# Compile the target
+$(target): $(source) $(depens)
+
+# Remove the target binary
+clean:
+	$(RM) $(target)

--- a/main.cpp
+++ b/main.cpp
@@ -1,0 +1,25 @@
+//
+// Created by basil-conto on 13/11/15.
+//
+
+#include <cstdlib>
+#include <vector>
+
+#include <opencv2/core.hpp>
+#include <opencv2/highgui.hpp>  // namedWindow, imshow, waitKey, destroyWindow
+
+#include "Images.h"
+
+int main() {
+    std::vector<cv::Mat> images = LoadImages(IMAGE_LOCATION, VIEW_FILES, 1);
+
+    for (size_t i = 0; i < images.size(); i++) {
+        const std::string filename{IMAGE_LOCATION + VIEW_FILES[i]};
+        cv::namedWindow(filename, cv::WINDOW_NORMAL);
+        cv::imshow(filename, images[i]);
+        cv::waitKey();
+        cv::destroyWindow(filename);
+    }
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
### Changes
- Add `main` binary to `.gitignore`.
- Move definitions from header to source file.
- Prefer `std::string` over `char*`.
- Use vector size as an implicit replacement for macro constants.
- Use uniform initialisation wherever applicable.
- Determine successful image read by checking `data` member is not `NULL`, as `empty()` is `true` in other cases as well.
- Prefer `EXIT_FAILURE` over system-dependent value, unless defining multiple error codes.
- Add sample `main` and `Makefile` files.
